### PR TITLE
Fix trigger name

### DIFF
--- a/sensors/webhook_sensor.py
+++ b/sensors/webhook_sensor.py
@@ -21,7 +21,7 @@ class GitHubWebhookSensor(Sensor):
         self._endpoints = self._config['endpoints']
         self._secret = self._config['secret'].encode('utf-8')
         self.app = Flask(__name__)
-        self.trigger_ref = "webhooks.github_event"
+        self.trigger_ref = "githubwebhook.github_event"
         self.log = self._sensor_service.get_logger(__name__)
 
         @self.app.route('/status')


### PR DESCRIPTION
Noticed documentation was not getting build on commits / merged and tracked it down to the trigger name.

All of our existing CI / CD rules use `githubwebhook.github_event` trigger name (grep for githubwebhook.github_event vs webhooks.github_event in {st2cd,st2ci}) so I changed it to this. That's also the name of a trigger registered by this sensor.

```bash
raceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/transport/consumers.py", line 85, in process
    response = self._handler.pre_ack_process(body)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/rules/worker.py", line 56, in pre_ack_process
    raise_on_no_trigger=True)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/utils.py", line 70, in create_trigger_instance
    raise StackStormDBObjectNotFoundError('Trigger not found for %s', trigger)
StackStormDBObjectNotFoundError: ('Trigger not found for %s', 'webhooks.github_event')
```

```bash
st2 trigger list
...
| githubwebhook.github_event           | githubwebhook | An example trigger.                                             |
...
```
