### PR TITLE
Migrate to config schema

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,0 +1,20 @@
+---
+  host:
+    description: FQDN or IP address to host the flask app for the sensor
+    type: string
+    default: 0.0.0.0
+  port:
+    description: Port that the flask app is listening on
+    type: integer
+    default: 8642
+  endpoints:
+    description: List of webhook endpoints that sensor supports
+    type: array
+    items:
+      type: string
+    default:
+      - "github/events"
+  secret:
+    description: Key to secure the endpoints
+    type: string
+    default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,0 @@
----
-  host: "0.0.0.0"
-  port: 8642
-  endpoints: 
-    - "github/events"
-  secret: ""

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: githubwebhook
 description: GitHub webhook sensor
-version: 0.0.3
+version: 0.0.4
 author: Patrick Hoolboom
 email: patrick@stackstorm.com


### PR DESCRIPTION
Local pack config is removed in st2 v2.4. Migrate the pack to use config schema.