### PR TITLE
Fix large CPU usage by the sensor

### DIFF
--- a/sensors/webhook_sensor.py
+++ b/sensors/webhook_sensor.py
@@ -68,7 +68,7 @@ class GitHubWebhookSensor(Sensor):
             return json.dumps({"response":"triggerposted"})
 
     def run(self):
-        self.app.run(host=self.host,port=self.port,debug=True, threaded=True)
+        self.app.run(host=self.host,port=self.port,debug=False, threaded=True)
 
     def cleanup(self):
         # This is called when the st2 system goes down. You can perform cleanup operations like


### PR DESCRIPTION
This sensor was constantly using 10% of the CPU on our build server.

It turns out that was due to the debug mode being enable. This change fixes that.